### PR TITLE
Fix for ambigous operator export from attoparsec and aeson

### DIFF
--- a/Biobase/BLAST/Import.hs
+++ b/Biobase/BLAST/Import.hs
@@ -24,7 +24,7 @@ import Control.Monad
 import Debug.Trace
 import Text.Printf
 import Biobase.BLAST.Types
-import Data.Aeson as A
+import qualified Data.Aeson as A
 
 -- | reads and parses tabular Blast result from provided filePath
 blastCmdJSON2FromFile :: String -> IO (Either String BlastCmdJSON2)

--- a/BiobaseBlast.cabal
+++ b/BiobaseBlast.cabal
@@ -1,5 +1,5 @@
 name:           BiobaseBlast
-version:        0.3.0.0
+version:        0.3.0.1
 author:         Christian Hoener zu Siederdissen, Florian Eggenhofer
 maintainer:     choener@bioinf.uni-leipzig.de
 homepage:       https://github.com/choener/BiobaseBlast
@@ -221,5 +221,5 @@ source-repository head
 
 source-repository this
   type:     git
-  location: https://github.com/choener/BiobaseBlast/tree/0.3.0.0
-  tag:      0.3.0.0
+  location: https://github.com/choener/BiobaseBlast/tree/0.3.0.1
+  tag:      0.3.0.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+0.3.0.1
+-------
+
+- Fix for newly ambigous ? operator export from attoparsec and aeson>=1.4.4.0 
+  in Import module 
+
 0.3.0.0
 -------
 


### PR DESCRIPTION
Hi, without this fix I have to introduce a constraint on aeson <=1.4.2.0 to make the library compile.
The newest aeson libraries expose the ? operator, causing ambiguity.
Plz review and merge :-) 